### PR TITLE
Nodebalancer zksync blockchain support

### DIFF
--- a/nodebalancer/cmd/nodebalancer/blockchain.go
+++ b/nodebalancer/cmd/nodebalancer/blockchain.go
@@ -36,6 +36,27 @@ var (
 		"net_version":   true,
 
 		"web3_clientVersion": true,
+
+		// zksync methods
+		"zks_estimateFee": true,
+		"zks_estimateGasL1ToL2": true,
+		"zks_getAllAccountBalances": true,
+		"zks_getBlockDetails": true,
+		"zks_getBridgeContracts": true,
+		"zks_getBytecodeByHash": true,
+		"zks_getConfirmedTokens": true,
+		"zks_getL1BatchBlockRange": true,
+		"zks_getL1BatchDetails": true,
+		"zks_getL2ToL1LogProof": true,
+		"zks_getL2ToL1MsgProof": true,
+		"zks_getMainContract": true,
+		"zks_getRawBlockTransactions": true,
+		"zks_getTestnetPaymaster": true,
+		"zks_getTokenPrice": true,
+		"zks_getTransactionDetails": true,
+		"zks_L1BatchNumber": true,
+		"zks_L1ChainId": true,
+
 	}
 )
 


### PR DESCRIPTION
Specified default zksync methods for nodebalancer from https://era.zksync.io/docs/api/api.html
