### PR TITLE
Bumped Humbug version to 0.3.2

### DIFF
--- a/moonstreamapi/requirements.txt
+++ b/moonstreamapi/requirements.txt
@@ -28,7 +28,7 @@ future==0.18.2
 greenlet==2.0.1
 h11==0.14.0
 hexbytes==0.3.0
-humbug==0.2.7
+humbug==0.3.2
 idna==3.4
 ipfshttpclient==0.8.0a2
 jmespath==1.0.1

--- a/moonstreamapi/setup.py
+++ b/moonstreamapi/setup.py
@@ -17,7 +17,7 @@ setup(
         "moonstream-entity>=0.0.5",
         "fastapi",
         "moonstreamdb>=0.3.4",
-        "humbug",
+        "humbug>=0.3.2",
         "pydantic",
         "pyevmasm",
         "python-dateutil",


### PR DESCRIPTION
With `humbug>=0.3.2` in `setup.py`.