### PR TITLE
Release packages update

### DIFF
--- a/.github/workflows/release.clients.python.yml
+++ b/.github/workflows/release.clients.python.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONSTREAM }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*

--- a/.github/workflows/release.mooncrawl.yml
+++ b/.github/workflows/release.mooncrawl.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONCRAWL }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*

--- a/.github/workflows/release.moonstreamapi.yml
+++ b/.github/workflows/release.moonstreamapi.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONSTREAMAPI }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*

--- a/.github/workflows/release.moonstreamdb.yml
+++ b/.github/workflows/release.moonstreamdb.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONSTREAMDB }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*

--- a/.github/workflows/release.moonstreamdbv3.yml
+++ b/.github/workflows/release.moonstreamdbv3.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONSTREAMDBV3 }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*

--- a/.github/workflows/release.types.python.yml
+++ b/.github/workflows/release.types.python.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_MOONSTREAM_TYPES }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*


### PR DESCRIPTION
Used `build` with support of [PEP 625](https://peps.python.org/pep-0625/).

Also used `MANIFEST.in` to include `version.txt` files in isolated build environment, detailed documation at: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html .

Packages with changes:
- PR https://github.com/moonstream-to/api/pull/1152
- PR https://github.com/moonstream-to/api/pull/1153